### PR TITLE
Update readme for zapsign context

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,191 +1,123 @@
-# Postman MCP Generator
+# ZapSign MCP Server
 
-Welcome to your generated MCP server! 🚀 This project was created with the [Postman MCP Generator](https://postman.com/explore/mcp-generator), configured to [Model Context Provider (MCP)](https://modelcontextprotocol.io/introduction) Server output mode. It provides you with:
-
-- ✅ An MCP-compatible server (`mcpServer.js`)
-- ✅ Automatically generated JavaScript tools for each selected Postman API request
-
-Let's set things up!
+A Model Context Protocol (MCP) server that exposes ZapSign API operations as callable tools for LLMs (e.g., Claude Desktop) or any MCP-compatible client.
 
 ## 🚦 Getting Started
 
 ### ⚙️ Prerequisites
+- Node.js v18+ (v20+ recommended)
+- npm
+- A ZapSign API token
 
-Before starting, please ensure you have:
+Note: Tools use the global `fetch` API available in Node v18+. If you must use an older Node version, adapt tools to import `node-fetch` and add it as a dependency.
 
-- [Node.js (v18+ required, v20+ recommended)](https://nodejs.org/)
-- [npm](https://www.npmjs.com/) (included with Node)
-
-Warning: if you run with a lower version of Node, `fetch` won't be present. Tools use `fetch` to make HTTP calls. To work around this, you can modify the tools to use `node-fetch` instead. Make sure that `node-fetch` is installed as a dependency and then import it as `fetch` into each tool file.
-
-### 📥 Installation & Setup
-
-**1. Install dependencies**
-
-Run from your project's root directory:
-
+### 📥 Installation
 ```sh
 npm install
 ```
 
-### 🔐 Set tool environment variables
-
-In the `.env` file, you'll see environment variable placeholders, one for each workspace that the selected tools are from. For example, if you selected requests from 2 workspaces, e.g. Acme and Widgets, you'll see two placeholders:
-
+### 🔐 Configuration
+Create a `.env` file in the project root with your ZapSign API token:
 ```
-ACME_API_KEY=
-WIDGETS_API_KEY=
+ZAPSIGN_WORKSPACE_API_KEY=your_zapsign_api_token_here
 ```
+This value is read by the tools (for example, see files under `tools/zapsign-workspace/api/`) to authenticate requests against `https://api.zapsign.com.br`.
 
-Update the values with actual API keys for each API. These environment variables are used inside of the generated tools to set the API key for each request. You can inspect a file in the `tools` directory to see how it works.
+## ▶️ Running the MCP Server
+You can run the server in STDIO mode (for Claude Desktop and most MCP clients) or in SSE mode (HTTP with Server-Sent Events).
 
-```javascript
-// environment variables are used inside of each tool file
-const apiKey = process.env.ACME_API_KEY;
-```
+### STDIO (typical for Claude Desktop)
+Use absolute paths to ensure the correct Node version is used.
 
-**Caveat:** This may not be correct for every API. The generation logic is relatively simple - for each workspace, we create an environment variable with the same name as the workspace slug, and then use that environment variable in each tool file that belongs to that workspace. If this isn't the right behavior for your chosen API, no problem! You can manually update anything in the `.env` file or tool files to accurately reflect the API's method of authentication.
-
-## 🌐 Test the MCP Server with Postman
-
-The MCP Server (`mcpServer.js`) exposes your automated API tools to MCP-compatible clients, such as Claude Desktop or the Postman Desktop Application. We recommend that you test the server with Postman first and then move on to using it with an LLM.
-
-The Postman Desktop Application is the easiest way to run and test MCP servers. Testing the downloaded server first is optional but recommended.
-
-**Step 1**: Download the latest Postman Desktop Application from [https://www.postman.com/downloads/](https://www.postman.com/downloads/).
-
-**Step 2**: Read out the documentation article [here](https://learning.postman.com/docs/postman-ai-agent-builder/mcp-requests/create/) and see how to create an MCP request inside the Postman app.
-
-**Step 3**: Set the type of the MCP request to `STDIO` and set the command to `node </absolute/path/to/mcpServer.js>`. If you have issues with using only `node` (e.g. an old version is used), supply an absolute path instead to a node version 18+. You can get the full path to node by running:
-
+1) Find your Node path and version:
 ```sh
 which node
-```
-
-To check the node version, run:
-
-```sh
 node --version
 ```
+Ensure it is v18+.
 
-To get the absolute path to `mcpServer.js`, run:
-
-```sh
-realpath mcpServer.js
-```
-
-Use the node command followed by the full path to `mcpServer.js` as the command for your new Postman MCP Request. Then click the **Connect** button. You should see a list of tools that you selected before generating the server. You can test that each tool works here before connecting the MCP server to an LLM.
-
-## 👩‍💻 Connect the MCP Server to Claude
-
-You can connect your MCP server to any MCP client. Here we provide instructions for connecting it to Claude Desktop.
-
-**Step 1**: Note the full path to node and the `mcpServer.js` from the previous step.
-
-**Step 2**. Open Claude Desktop → **Settings** → **Developers** → **Edit Config** and add a new MCP server:
-
+2) In Claude Desktop → Settings → Developers → Edit Config, add:
 ```json
 {
   "mcpServers": {
-    "<server_name>": {
-      "command": "<absolute/path/to/node>",
-      "args": ["<absolute/path/to/mcpServer.js>"]
+    "zapsign-mcp": {
+      "command": "/absolute/path/to/node",
+      "args": ["/absolute/path/to/mcpServer.js"]
     }
   }
 }
 ```
+Restart Claude Desktop and enable the server. If tools do not appear, verify Node version and the `.env` configuration.
 
-Restart Claude Desktop to activate this change. Make sure the new MCP is turned on and has a green circle next to it. If so, you're ready to begin a chat session that can use the tools you've connected.
-
-**Warning**: If you don't supply an absolute path to a `node` version that is v18+, Claude (and other MCP clients) may fall back to another `node` version on the system of a previous version. In this case, the `fetch` API won't be present and tool calls will not work. If that happens, you can a) install a newer version of node and point to it in the command, or b) import `node-fetch` into each tool as `fetch`, making sure to also add the `node-fetch` dependency to your package.json.
-
-### Additional Options
-
-#### 🐳 Docker Deployment (Production)
-
-For production deployments, you can use Docker:
-
-**1. Build Docker image**
-
-```sh
-docker build -t <your_server_name> .
-```
-
-**2. Claude Desktop Integration**
-
-Add Docker server configuration to Claude Desktop (Settings → Developers → Edit Config):
-
-```json
-{
-  "mcpServers": {
-    "<your_server_name>": {
-      "command": "docker",
-      "args": ["run", "-i", "--rm", "--env-file=.env", "<your_server_name>"]
-    }
-  }
-}
-```
-
-> Add your environment variables (API keys, etc.) inside the `.env` file.
-
-The project comes bundled with the following minimal Docker setup:
-
-```dockerfile
-FROM node:22.12-alpine AS builder
-
-WORKDIR /app
-COPY package.json package-lock.json ./
-RUN npm install
-
-COPY . .
-
-ENTRYPOINT ["node", "mcpServer.js"]
-```
-
-#### 🌐 Server-Sent Events (SSE)
-
-To run the server with Server-Sent Events (SSE) support, use the `--sse` flag:
-
+### SSE (HTTP via Server-Sent Events)
 ```sh
 node mcpServer.js --sse
 ```
+- Defaults to port `3001` (override with `PORT`).
+- Endpoint: `GET /sse` to open an SSE session; `POST /messages?sessionId=...` for messages.
 
-## 🛠️ Additional CLI commands
-
-#### List tools
-
-List descriptions and parameters from all generated tools with:
-
+### 🐳 Docker
+A minimal Docker setup is included. Build and run:
 ```sh
+docker build -t zapsign-mcp .
+```
+Claude Desktop (Edit Config):
+```json
+{
+  "mcpServers": {
+    "zapsign-mcp": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "--env-file=.env", "zapsign-mcp"]
+    }
+  }
+}
+```
+Put your variables in `.env` (e.g., `ZAPSIGN_WORKSPACE_API_KEY`).
+
+## 🧰 Available Tools (ZapSign)
+These tools are discovered from `tools/paths.js` and exposed to MCP clients:
+
+- list_templates: List templates from the ZapSign API.
+- get_docs: Get documents from the ZapSign API.
+- delete_doc: Delete a document using the ZapSign API.
+- detail_doc: Retrieve details of a document from the ZapSign API.
+- delete_signer: Delete a signer from the API.
+- detail_template: Retrieve details of a specific template from ZapSign.
+- delete_webhook_header: Delete a webhook header.
+- add_time_stamp: Add a time stamp to a document using the ZapSign API.
+- create_webhook_header: Create a webhook header in the ZapSign API.
+- detail_siner: Retrieve details of a signer from the API.
+- add_signer: Add a signer to a document in ZapSign.
+- sign_in_batch: Sign in a batch using the ZapSign API.
+- delete_webhook: Delete a webhook from the ZapSign API.
+- place_signatures: Place signatures on a document using the ZapSign API.
+- update_siner: Update a signer in the ZapSign API.
+- add_extra_doc: Add an extra document to ZapSign.
+- add_extra_doc_from_template: Add an extra document from a template in ZapSign.
+- create_webhook: Create a webhook in ZapSign.
+- create_doc_from_upload_async: Create a document from an uploaded PDF asynchronously.
+- create_doc_from_template: Create a document from a template using the ZapSign API.
+- create_doc_from_upload: Create a document from an uploaded DOCX file.
+- create_doc_from_template_async: Create a document from a template asynchronously using the ZapSign API.
+- create_doc_from_upload_pdf: Create a document from an uploaded PDF.
+
+You can also list tool names and schemas locally:
+```sh
+npm run list-tools
+# or
 node index.js tools
 ```
 
-Example:
+## ➕ Adding or Updating Tools
+- Add a new tool module under `tools/zapsign-workspace/api/` following the existing pattern (`apiTool` export with a `function` and a `definition`).
+- Register the new file in `tools/paths.js` so it’s discovered by the server.
+- Ensure any required environment variables are read from `.env`.
 
-```
-Available Tools:
+## ⚠️ Notes & Tips
+- If Claude Desktop or your MCP client cannot invoke tools, verify:
+  - Node is v18+ (for native `fetch`).
+  - `.env` contains a valid `ZAPSIGN_WORKSPACE_API_KEY`.
+  - The absolute paths in the client config are correct.
 
-Workspace: acme-workspace
-  Collection: useful-api
-    list_all_customers
-      Description: Retrieve a list of useful things.
-      Parameters:
-        - magic: The required magic power
-        - limit: Number of results returned
-        [...additional parameters...]
-```
-
-## ➕ Adding New Tools
-
-Extend your MCP server with more tools easily:
-
-1. Visit [Postman MCP Generator](https://postman.com/explore/mcp-generator).
-2. Pick new API request(s), generate a new MCP server, and download it.
-3. Copy new generated tool(s) into your existing project's `tools/` folder.
-4. Update your `tools/paths.js` file to include new tool references.
-
-## 💬 Questions & Support
-
-Visit the [Postman MCP Generator](https://postman.com/explore/mcp-generator) page for updates and new capabilities.
-
-Join the `#mcp-lab` channel in the [Postman Discord](https://discord.gg/HQJWM8YF) to share what you've built and get help.
+## 📄 License
+MIT


### PR DESCRIPTION
Refactor `README.md` to describe the server as a ZapSign MCP server, removing Postman generator specific content.

---
<a href="https://cursor.com/background-agent?bcId=bc-3480850a-8663-4304-ba3d-d8c0eef436fa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3480850a-8663-4304-ba3d-d8c0eef436fa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

